### PR TITLE
Use market interface instead of having to specify market contract

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ const contractInfo = _.fromPairs([
         ['UltimateOracle'],
         ['UltimateOracleFactory', { gas: parseInt('900,000') }],
         ['LMSRMarketMaker'],
-        ['StandardMarket', { gas: parseInt('300,000') }],
+        ['Market', { gas: parseInt('300,000') }],
         ['StandardMarketFactory', { gas: parseInt('2,000,000') }]
 ].map(([name, defaults]) => [name, {
     artifact: require(`@gnosis.pm/gnosis-core-contracts/build/contracts/${name}.json`),

--- a/src/markets.js
+++ b/src/markets.js
@@ -24,6 +24,6 @@ export async function createMarket (opts) {
         methodArgs: args,
         eventName: 'MarketCreation',
         eventArgName: 'market',
-        resultContract: opts.marketContract
+        resultContract: this.contracts.Market
     })
 }

--- a/test/test_gnosis.js
+++ b/test/test_gnosis.js
@@ -116,7 +116,6 @@ describe('Gnosis', function () {
                 event: event,
                 marketMaker: gnosis.lmsrMarketMaker,
                 fee: 100,
-                marketContract: gnosis.contracts.StandardMarket
             })
             assert(market)
         })
@@ -139,7 +138,6 @@ describe('Gnosis', function () {
                 event: event,
                 marketMaker: gnosis.lmsrMarketMaker,
                 fee: 100,
-                marketContract: gnosis.contracts.StandardMarket
             })
 
             requireEventFromTXResult(await gnosis.etherToken.deposit({ value: '100000000' }), 'Deposit')


### PR DESCRIPTION
Yeah, so it turns out Truffle does support pure abstract contracts. Just it took `cd`ing into the gnosis-core-contracts directory in node_modules to run Truffle commands to have those get generated by the build process.