### PR TITLE
Base provider type check on existence of send and sendAsync

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -182,7 +182,11 @@ class Gnosis {
             }
         } else if (typeof provider === 'string') {
             this.web3 = new Web3(new Web3.providers.HttpProvider(provider))
-        } else if (typeof provider === 'object' && provider.constructor.name.toLowerCase().endsWith('provider')) {
+        } else if (
+            typeof provider === 'object' &&
+            typeof provider.send === 'function' &&
+            typeof provider.sendAsync === 'function'
+        ) {
             this.web3 = new Web3(provider)
         } else {
             throw new TypeError(`provider of type '${typeof provider}' not supported`)

--- a/test/test_gnosis.js
+++ b/test/test_gnosis.js
@@ -70,6 +70,18 @@ describe('Gnosis', function () {
         assert(gnosis)
     })
 
+    it('initializes with a provider that has a mangled name', async () => {
+        class Mangled extends TestRPC.provider().constructor {}
+
+        const provider = new Mangled()
+        assert(provider.constructor.name === 'Mangled')
+
+        let gnosis = await Gnosis.create({
+            ethereum: provider,
+        })
+        assert(gnosis)
+    })
+
     it('initializes with contracts containing gas stats', async () => {
         let gnosis = await Gnosis.create()
         assert(gnosis.contracts)


### PR DESCRIPTION
See PM-181

Basically, minifiers can mangle provider names, so a more robust check for Provider-likeness is to look at the schema of the passed object.