### PR TITLE
`buyAllOutcomes` default gas limit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -145,16 +145,16 @@
       }
     },
     "@gnosis.pm/gnosis-core-contracts": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@gnosis.pm/gnosis-core-contracts/-/gnosis-core-contracts-1.0.2.tgz",
-      "integrity": "sha512-rX+a/ezKngADvjhuVX/dR8oLcQmKb0vv0abmo3S01yKfstpVhZPv9xdHW1LqbZ+15aqaXVVYGKE3fV01kJVVbQ=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@gnosis.pm/gnosis-core-contracts/-/gnosis-core-contracts-1.0.3.tgz",
+      "integrity": "sha512-Fzcg+Qrg2jb0hITgB1MAMLvuOtvIaYrBkkerD05estAPb8fl7zRxBMIehdJ0zYHv79WgMMRXc5fSBx2guz3KEg=="
     },
     "@gnosis.pm/olympia-token": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@gnosis.pm/olympia-token/-/olympia-token-1.1.0.tgz",
       "integrity": "sha512-g/x+xf+INYK0EDyLY9YofOR3nNYnLrGlLTWxAmOyAwawj1VRLUvCPV/V5y5sfITT8IwumrsuUdAl/I4dIbesEw==",
       "requires": {
-        "@gnosis.pm/gnosis-core-contracts": "1.0.2"
+        "@gnosis.pm/gnosis-core-contracts": "1.0.3"
       }
     },
     "abstract-leveldown": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "truffle-hdwallet-provider": "0.0.3"
   },
   "dependencies": {
-    "@gnosis.pm/gnosis-core-contracts": "^1.0.2",
+    "@gnosis.pm/gnosis-core-contracts": "^1.0.3",
     "@gnosis.pm/olympia-token": "^1.1.0",
     "babel-polyfill": "^6.26.0",
     "babel-runtime": "^6.26.0",

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ const windowLoaded = new Promise((accept, reject) => {
 
 const gasStatsData = require('@gnosis.pm/gnosis-core-contracts/build/gas-stats.json')
 const gasLimit = 4e6
-const gasDefaultMaxMultiplier = 1.5
+const gasDefaultMaxMultiplier = 2
 
 const implementationInterfaceMap = {
     StandardMarket: ['Market'],

--- a/test/test_gnosis.js
+++ b/test/test_gnosis.js
@@ -476,6 +476,19 @@ describe('Gnosis', function () {
             })
             assert(await gnosis.resolveEvent.estimateGas({ event, using: 'stats' }) > 0)
         })
+
+        it('by default supplies a gas limit suitable for buyAllOutcomes', async () => {
+            let event = await gnosis.createCategoricalEvent({
+                collateralToken: gnosis.etherToken,
+                oracle: oracle,
+                outcomeCount: 2
+            })
+
+            const funding = 1e18
+            requireEventFromTXResult(await gnosis.etherToken.deposit({ value: funding }), 'Deposit')
+            requireEventFromTXResult(await gnosis.etherToken.approve(event.address, funding), 'Approval')
+            requireEventFromTXResult(await event.buyAllOutcomes(funding), 'OutcomeTokenSetIssuance')
+        })
     })
 
     describe('#markets', () => {


### PR DESCRIPTION
See https://github.com/gnosis/gnosis.js/issues/99

With both the core contract gas stats reporting a limit of ~160k and the gas limit multiplier bumped to 2, the `buyAllOutcomes` default gas limit should accomodate the highest value found reported in the issue. Admittedly, this is a bit kludgier than actually figuring out what is going on with this, but it will work for now.